### PR TITLE
Added function to delete models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog 
 
+## Version 3.2.15 - 2021-05-27
+
+- Added delete_model 
+
 ## Version 3.2.14 - 2021-05-25
 
 - Added login_urls and default_login_url to create_app_client

--- a/las/client.py
+++ b/las/client.py
@@ -799,7 +799,7 @@ class Client:
 
         >>> from las.client import Client
         >>> client = Client()
-        >>> client.delete_asset('<model_id>')
+        >>> client.delete_model('<model_id>')
 
         :param model_id: Id of the model
         :type model_id: str

--- a/las/client.py
+++ b/las/client.py
@@ -794,6 +794,23 @@ class Client:
         body.update(**optional_args)
         return self._make_request(requests.patch, f'/models/{model_id}', body=body)
 
+    def delete_model(self, model_id: str) -> Dict:
+        """Delete the model with the provided model_id, calls the DELETE /models/{modelId} endpoint.
+
+        >>> from las.client import Client
+        >>> client = Client()
+        >>> client.delete_asset('<model_id>')
+
+        :param model_id: Id of the model
+        :type model_id: str
+        :return: Model response from REST API
+        :rtype: dict
+
+        :raises: :py:class:`~las.InvalidCredentialsException`, :py:class:`~las.TooManyRequestsException`,\
+ :py:class:`~las.LimitExceededException`, :py:class:`requests.exception.RequestException`
+        """
+        return self._make_request(requests.delete, f'/models/{model_id}')
+
     def create_prediction(
         self,
         document_id: str,

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.md') as fp:
 
 setup(
     name='lucidtech-las',
-    version='3.2.14',
+    version='3.2.15',
     description='Python SDK for Lucidtech AI Services',
     long_description=readme,
     long_description_content_type='text/markdown',

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -70,3 +70,9 @@ def assert_model(response):
     assert 'preprocessConfig' in response, 'Missing preprocessConfig in response'
     assert 'fieldConfig' in response, 'Missing fieldConfig in response'
     assert 'description' in response, 'Missing description in response'
+
+@pytest.mark.skip(reason='DELETE does not work for the mocked API')
+def test_delete_model(client: Client):
+    model_id = service.create_model_id()
+    response = client.delete_model(model_id)
+    assert 'modelId' in response, 'Missing modelId in response'


### PR DESCRIPTION
Function for deleting models through the DELETE endpoint. Added test as well based on the test written for secrets which was similar in delete requirements.